### PR TITLE
add a way to get follow side events, especially catchup

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ exports.changes = function (db, q) {
           feed.pause();
         }
       });
+      if (q.on_catchup && typeof q.on_catchup === 'function') {
+        feed.on('catchup', q.on_catchup)
+      }      
     });
     var _resume = output.resume;
     output.resume = function () {


### PR DESCRIPTION
I need a way to get callbacks on events that should not go through the stream. An example here is the catchup event. 

Now one can pass a callback, via the config, eg: 

```
couchr.changes(config.log_database, {
   on_catchup: function (seq_num) {  }
});
```
